### PR TITLE
update specs for swap()

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,12 +937,15 @@ constexpr void swap(static_vector<T, N>& x,
   noexcept(noexcept(x.swap(y)));
 ```
 
-> - _Constraints_: This function shall not participate in overload resolution
->   unless `is_swappable_v<T>` is `true`.
+> - _Mandates_: `is_swappable_v<T>` is `true` and `is_move_constructible_v<T>` is `true`.
 >
 > - _Effects_: As if by `x.swap(y)`.
 >
 > - _Complexity_: Linear in `size()` and `x.size()`.
+>
+> - [*Note:* Unlike the `swap` function for other containers, this overload takes linear time, may exit via an exception, and does not cause iterators to become associated with the other container.
+*&mdash; end note*]
+
 
 # <a id="ACKNOWLEDGEMENTS"></a>6. Acknowledgments
 


### PR DESCRIPTION
Please, do not just apply this change. I just want to discuss this, as I am not sure myself what your goals are.

When you only hide this overload of `std::swap` in cases where `T` is not swappable the effect will be that the generic version of `std::swap` will become a viable candidate, and this generic `swap` does not require the `T` to be swappable. So instead, maybe you just want a hard error? If so, you can apply this commit. The note is taken from the specification of `swap` for `std::array`: http://eel.is/c++draft/array#members-5

The constraints for the member `swap` can be left as they are: there is no interaction with other overloads.